### PR TITLE
README.md: WACZ Signing and Verification url fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ This repository contains technical specifications used by the [Webrecorder] proj
 [Webrecorder]: https://webrecorder.net
 [Web Archive Collection Zipped (WACZ)]: https://specs.webrecorder.net/wacz/latest/
 [Use Cases for Decentralized Web Archives]: https://specs.webrecorder.net/use-cases/latest/
-[WACZ Signing and Verification]: https://specs.webrecorder.net/auth/latest/
+[WACZ Signing and Verification]: https://specs.webrecorder.net/wacz-auth/latest/
 [Crawl Index JSON (CDXJ)]: https://specs.webrecorder.net/cdxj/latest/


### PR DESCRIPTION
Minor edit:
https://specs.webrecorder.net/auth/latest/ should be https://specs.webrecorder.net/wacz-auth/latest/.
https://specs.webrecorder.net/auth/latest/ returns HTTP 404.