### PR TITLE
Correct minor typos in WACZ spec Section 7

### DIFF
--- a/wacz/1.1.1/index.md
+++ b/wacz/1.1.1/index.md
@@ -323,7 +323,7 @@ Because they are ZIP files WACZ can be hosted on the web as static files. This
 allows web archives to be easily maintained over time without relying on complex
 server side software, apart from widely available, open source, and well tested
 web server applications. If desirable WACZ files can be managed and made
-accessibile using HTTP object stores available from cloud hosting providers, and
+accessible using HTTP object stores available from cloud hosting providers, and
 content delivery networks that geographically position web-archives closer to
 their users. However there are certain considerations to make when publishing
 WACZ files.

--- a/wacz/1.1.1/index.md
+++ b/wacz/1.1.1/index.md
@@ -324,7 +324,7 @@ allows web archives to be easily maintained over time without relying on complex
 server side software, apart from widely available, open source, and well tested
 web server applications. If desirable WACZ files can be managed and made
 accessibile using HTTP object stores available from cloud hosting providers, and
-content deliver networks that geographically position web-archives closer to
+content delivery networks that geographically position web-archives closer to
 their users. However there are certain considerations to make when publishing
 WACZ files.
 

--- a/wacz/1.2.0/index.md
+++ b/wacz/1.2.0/index.md
@@ -351,7 +351,7 @@ allows web archives to be easily maintained over time without relying on complex
 server side software, apart from widely available, open source, and well tested
 web server applications. If desirable WACZ files can be managed and made
 accessibile using HTTP object stores available from cloud hosting providers, and
-content deliver networks that geographically position web-archives closer to
+content delivery networks that geographically position web-archives closer to
 their users. However there are certain considerations to make when publishing
 WACZ files.
 

--- a/wacz/1.2.0/index.md
+++ b/wacz/1.2.0/index.md
@@ -350,7 +350,7 @@ Because they are ZIP files WACZ can be hosted on the web as static files. This
 allows web archives to be easily maintained over time without relying on complex
 server side software, apart from widely available, open source, and well tested
 web server applications. If desirable WACZ files can be managed and made
-accessibile using HTTP object stores available from cloud hosting providers, and
+accessible using HTTP object stores available from cloud hosting providers, and
 content delivery networks that geographically position web-archives closer to
 their users. However there are certain considerations to make when publishing
 WACZ files.


### PR DESCRIPTION
Two more typos I found when reading [the 'Publishing' section](https://specs.webrecorder.net/wacz/1.1.1/#publishing) of the WACZ spec yesterday.

accessib~~i~~le -> accessible

and

content deliver networks -> content deliver**y** networks

This PR updates both WACZ 1.1.1 and 1.2.0 documents.